### PR TITLE
Added the option to set a fixed MQTT topic for all messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,9 @@ Set the following optional environment variables before invoking
    prefixing the topic name.
 -  ``MQTTFILTER`` (default None) allows modifying payload (see below).
    Takes path to a Python file (e.g. ``"/path/to/example-filter.py"``.
+-  ``MQTTFIXEDTOPIC`` (default None) sets a MQTT topic to which
+  ALL messages are published. If set, the ``MQTTPREFIX`` setting is
+  overruled and ignored.
 
 -  Set ``WATCHDEBUG`` (default: ``0``) to ``1`` to show debugging
    information.

--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,8 @@ Set the following optional environment variables before invoking
 -  ``MQTTFILTER`` (default None) allows modifying payload (see below).
    Takes path to a Python file (e.g. ``"/path/to/example-filter.py"``.
 -  ``MQTTFIXEDTOPIC`` (default None) sets a MQTT topic to which
-  ALL messages are published. If set, the ``MQTTPREFIX`` setting is
-  overruled and ignored.
+   all messages are published. If set, the ``MQTTPREFIX`` setting is
+   overruled and ignored.
 
 -  Set ``WATCHDEBUG`` (default: ``0``) to ``1`` to show debugging
    information.

--- a/mqtt-watchdir.py
+++ b/mqtt-watchdir.py
@@ -50,10 +50,21 @@ MQTTRETAIN      = int(os.getenv('MQTTRETAIN', 0))
 MQTTPREFIX      = os.getenv('MQTTPREFIX', 'watch')
 MQTTFILTER      = os.getenv('MQTTFILTER', None)
 
+# Publish all messages to a fixed topic. E.g. if the file contents already/also 
+# contains the name of the file or in certain situations with retained messages.
+# Overrules and ignores the MQTTPREFIX setting.
+MQTTFIXEDTOPIC  = os.getenv('MQTTFIXEDTOPIC', None)
+
 WATCHDEBUG      = os.getenv('WATCHDEBUG', 0)
 
 if MQTTPREFIX == '':
     MQTTPREFIX = None
+
+if MQTTFIXEDTOPIC == '':
+    MQTTFIXEDTOPIC = None
+
+if MQTTFIXEDTOPIC:
+    print 'Publishing ALL messages to the topic: %s' % MQTTFIXEDTOPIC
 
 ignore_patterns = [ '*.swp', '*.o', '*.pyc' ]
 
@@ -122,13 +133,16 @@ class MyHandler(PatternMatchingEventHandler):
         # Create relative path name and append to topic prefix
         filename = path.replace(DIR + '/', '')
 
-        if WATCHDEBUG:
-            print "%s %s" % (op, filename)
-
-        if MQTTPREFIX is not None:
-            topic = '%s/%s' % (MQTTPREFIX, filename)
+        if MQTTFIXEDTOPIC is not None:
+            topic = MQTTFIXEDTOPIC
         else:
-            topic = filename
+            if MQTTPREFIX is not None:
+                topic = '%s/%s' % (MQTTPREFIX, filename)
+            else:
+                topic = filename
+
+        if WATCHDEBUG:
+            print "%s %s. Topic: %s" % (op, filename, topic)
 
         if op == 'DEL':
             payload = None


### PR DESCRIPTION
Basically the title says it all. It is now possible to send all messages to a single, fixed topic. Sometimes this can be convenient. E.g. when the filename is already in the contents of the file and/or when working with certain retainment situations.
